### PR TITLE
Fix review-blocking extension build paths

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   ],
 
   "background": {
-    "service_worker": "dist/background.js",
+    "service_worker": "background.js",
     "type": "module"
   },
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "copy-assets": "cp manifest.json dist/ && cp popup.html dist/ && cp popup.css dist/ && mkdir -p dist/icons && cp -r icons/* dist/icons/ 2>/dev/null || true && mkdir -p dist/data/quips && cp -r src/data/quips/* dist/data/quips/ 2>/dev/null || true",
     "lint": "tsc --noEmit",
     "package": "npm run build && cd dist && zip -r ../TabbyMcTabface-v1.0.0.zip .",
-    "dev": "npm run build:watch"
+    "dev": "npm run build:watch",
+    "verify:build-artifacts": "node scripts/verify-build-artifacts.mjs"
   },
   "keywords": [
     "sdd",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:coverage": "vitest --coverage",
     "build": "npm run clean && npm run compile && npm run build:popup && npm run copy-assets",
     "build:watch": "tsc -p tsconfig.build.json --watch",
-    "build:popup": "tsc src/ui/popup.ts --outDir dist --target ES2020 --lib ES2020,DOM --module ES2020 --moduleResolution bundler --esModuleInterop --skipLibCheck",
+    "build:popup": "tsc src/ui/popup.ts --outDir dist --rootDir src/ui --target ES2020 --lib ES2020,DOM --module ES2020 --moduleResolution bundler --esModuleInterop --skipLibCheck",
     "compile": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "copy-assets": "cp manifest.json dist/ && cp popup.html dist/ && cp popup.css dist/ && mkdir -p dist/icons && cp -r icons/* dist/icons/ 2>/dev/null || true && mkdir -p dist/data/quips && cp -r src/data/quips/* dist/data/quips/ 2>/dev/null || true",

--- a/scripts/verify-build-artifacts.mjs
+++ b/scripts/verify-build-artifacts.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * Verify Chrome extension build and package path expectations.
+ *
+ * This intentionally validates the built `dist/` directory as the extension
+ * root, so manifest and popup paths must not include a `dist/` prefix.
+ */
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const distDir = 'dist';
+const packageFile = 'TabbyMcTabface-v1.0.0.zip';
+
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function requireFile(path) {
+  if (!existsSync(path) || !statSync(path).isFile()) {
+    fail(`Missing required file: ${path}`);
+  }
+}
+
+function requireNoDistPrefix(label, value) {
+  if (typeof value === 'string' && value.includes('dist/')) {
+    fail(`${label} must not include a dist/ prefix: ${value}`);
+  }
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function readZipFile(zipPath, filePath) {
+  return execFileSync('unzip', ['-p', zipPath, filePath], { encoding: 'utf8' });
+}
+
+function listZip(zipPath) {
+  return execFileSync('unzip', ['-Z1', zipPath], { encoding: 'utf8' })
+    .split('\n')
+    .filter(Boolean);
+}
+
+const requiredDistFiles = [
+  'background.js',
+  'manifest.json',
+  'popup.css',
+  'popup.html',
+  'popup.js',
+  'icons/icon16.png',
+  'icons/icon32.png',
+  'icons/icon48.png',
+  'icons/icon128.png',
+];
+
+for (const file of requiredDistFiles) {
+  requireFile(join(distDir, file));
+}
+
+if (existsSync(join(distDir, 'ui'))) {
+  fail('Duplicate popup output directory must not exist: dist/ui');
+}
+
+const popupJsPath = join(distDir, 'popup.js');
+if (existsSync(popupJsPath)) {
+  const popupJs = readFileSync(popupJsPath, 'utf8');
+  const popupControllerMarkers = [
+    'async function init()',
+    'async function updateStats()',
+    'async function handleFeelingLucky()',
+    'async function handleCreateGroup()',
+    'chrome.runtime.sendMessage',
+    'DOMContentLoaded',
+  ];
+
+  for (const marker of popupControllerMarkers) {
+    if (!popupJs.includes(marker)) {
+      fail(`dist/popup.js is missing compiled popup controller marker: ${marker}`);
+    }
+  }
+}
+
+const manifestPath = join(distDir, 'manifest.json');
+if (existsSync(manifestPath)) {
+  const manifest = readJson(manifestPath);
+  const serviceWorker = manifest.background?.service_worker;
+
+  if (serviceWorker !== 'background.js') {
+    fail(`dist/manifest.json background.service_worker must be background.js, got: ${serviceWorker}`);
+  }
+
+  requireNoDistPrefix('dist/manifest.json background.service_worker', serviceWorker);
+
+  for (const [size, iconPath] of Object.entries(manifest.icons ?? {})) {
+    requireNoDistPrefix(`dist/manifest.json icons.${size}`, iconPath);
+    requireFile(join(distDir, iconPath));
+  }
+
+  for (const [size, iconPath] of Object.entries(manifest.action?.default_icon ?? {})) {
+    requireNoDistPrefix(`dist/manifest.json action.default_icon.${size}`, iconPath);
+    requireFile(join(distDir, iconPath));
+  }
+}
+
+const popupHtmlPath = join(distDir, 'popup.html');
+if (existsSync(popupHtmlPath)) {
+  const popupHtml = readFileSync(popupHtmlPath, 'utf8');
+  if (!popupHtml.includes('<script src="popup.js"></script>')) {
+    fail('dist/popup.html must reference popup.js');
+  }
+  if (!popupHtml.includes('href="popup.css"')) {
+    fail('dist/popup.html must reference popup.css');
+  }
+  if (popupHtml.includes('dist/')) {
+    fail('dist/popup.html must not include dist/ prefixes');
+  }
+}
+
+if (existsSync(packageFile)) {
+  const zipEntries = listZip(packageFile);
+  const zipEntrySet = new Set(zipEntries);
+
+  for (const file of requiredDistFiles) {
+    if (!zipEntrySet.has(file)) {
+      fail(`Package is missing required file: ${file}`);
+    }
+  }
+
+  const distPrefixedEntries = zipEntries.filter((entry) => entry.startsWith('dist/'));
+  if (distPrefixedEntries.length > 0) {
+    fail(`Package entries must not be dist/-prefixed: ${distPrefixedEntries.join(', ')}`);
+  }
+
+  const packagedManifest = JSON.parse(readZipFile(packageFile, 'manifest.json'));
+  const packagedServiceWorker = packagedManifest.background?.service_worker;
+  if (packagedServiceWorker !== 'background.js') {
+    fail(`Packaged manifest background.service_worker must be background.js, got: ${packagedServiceWorker}`);
+  }
+  requireNoDistPrefix('packaged manifest background.service_worker', packagedServiceWorker);
+
+  const packagedPopupHtml = readZipFile(packageFile, 'popup.html');
+  if (!packagedPopupHtml.includes('<script src="popup.js"></script>')) {
+    fail('Packaged popup.html must reference popup.js');
+  }
+  if (packagedPopupHtml.includes('dist/')) {
+    fail('Packaged popup.html must not include dist/ prefixes');
+  }
+} else {
+  console.warn(`Package ${packageFile} not found; skipping archive checks.`);
+}
+
+if (failures.length > 0) {
+  console.error('Build artifact verification failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('Build artifact verification passed.');

--- a/src/impl/__tests__/tab-management.integration.test.ts
+++ b/src/impl/__tests__/tab-management.integration.test.ts
@@ -314,8 +314,10 @@ describe('Tab Management Integration Tests', () => {
 
       // Assert
       assertOk(result);
-      // Verify ungroup was called
-      expect(mockTabs.createGroupCalls.length).toBeGreaterThan(1);
+      // Verify ungroup was called (not a second createGroup call)
+      expect(mockTabs.ungroupTabsCalls).toHaveLength(1);
+      expect(mockTabs.ungroupTabsCalls[0].tabIds).toEqual([1, 2, 3]);
+      expect(mockTabs.createGroupCalls).toHaveLength(1);
     });
 
     it('returns error for non-existent group', async () => {

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -5,7 +5,6 @@
  * CONTRACT: Popup UI Controller v1.0.0
  */
 
-import { Result } from '../utils/Result';
 
 interface TabStats { tabCount: number; groupCount: number; quipCount: number; }
 interface BrowserContext { tabCount: number; groupCount: number; tabs: chrome.tabs.Tab[]; groups: chrome.tabGroups.TabGroup[]; }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -48,6 +48,7 @@
     "dist",
     "**/*.test.ts",
     "**/__tests__/**",
-    "src/mocks/**"
+    "src/mocks/**",
+    "src/ui/**"
   ]
 }


### PR DESCRIPTION
### Motivation
- Fix the reviewer-blocking popup script path mismatch so `popup.html` loads the JS that `npm run build` actually produces. 
- Prevent duplicate popup outputs (both `dist/ui/popup.js` and `dist/popup.js`) by making the popup compile step canonical. 
- Address a failing integration test assertion discovered while validating the fixes. 
- Keep packaged manifest and build layout consistent with docs and the unpacked-extension expectations.

### Description
- Updated the popup build step to compile from `src/ui` into `dist/popup.js` by adding `--rootDir src/ui` to the `build:popup` script in `package.json`. 
- Excluded `src/ui/**` from the main TypeScript build in `tsconfig.build.json` so the popup is only emitted by the dedicated popup build step. 
- Removed an unused `Result` import from `src/ui/popup.ts` to avoid forcing extra dependency output when flattening the popup build. 
- Adjusted `manifest.json` to reference the service worker as `background.js` (matching the built layout when `dist/` is used as the extension root). 
- Fixed the failing integration assertion in `src/impl/__tests__/tab-management.integration.test.ts` to assert the `ungroupTabs` call was made (and that it has the expected tab IDs) instead of expecting an extra `createGroup` call.

### Testing
- Built the project with `npm run build` and verified the produced artifacts include `dist/background.js`, `dist/manifest.json`, `dist/popup.html`, and `dist/popup.js` and that `dist/ui/popup.js` is no longer emitted. 
- Ran the test suite with `npm test`; initial failure in the delete-group integration test was reproduced, the test was updated, and the suite was re-run successfully. The final automated test run reported: `305 passed | 1 skipped` across the test files. 
- Manual Chrome extension load / interactive popup click-through was not performed in this environment and remains a manual verification step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a064d41f37c83209d8145d577d600d1)

## Summary by Sourcery

Align extension build outputs and manifest paths with the expected runtime layout and correct a related integration test expectation.

Bug Fixes:
- Ensure the popup script is built and referenced from the correct path so the extension popup loads the compiled JS.
- Adjust the background service worker path in the manifest to match the built extension layout.
- Fix the tab management integration test to assert the ungroup behavior and group creation calls accurately.

Enhancements:
- Simplify the popup UI code by removing an unused Result import.

Build:
- Update the popup build script to compile from the UI source directory into the canonical dist layout and avoid duplicate popup outputs.
- Refine the TypeScript build configuration so popup UI files are only emitted by the dedicated popup build step.

Tests:
- Update the tab management integration test to validate a single ungroupTabs call with expected tab IDs and only one createGroup call.